### PR TITLE
Remove respond_to in DceLti::ConfigsController

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dce_lti (0.5.3)
+    dce_lti (0.5.4)
       activerecord-session_store (~> 0.1.1)
       ims-lti (~> 1.1)
       p3p (~> 1.2.0)
@@ -136,7 +136,7 @@ GEM
     shoulda-matchers (2.7.0)
       activesupport (>= 3.0.0)
     slop (3.6.0)
-    sprockets (3.1.0)
+    sprockets (3.2.0)
       rack (~> 1.0)
     sprockets-rails (2.3.1)
       actionpack (>= 3.0)

--- a/app/controllers/dce_lti/configs_controller.rb
+++ b/app/controllers/dce_lti/configs_controller.rb
@@ -1,7 +1,6 @@
 module DceLti
   class ConfigsController < ApplicationController
     skip_before_filter :authenticate_via_lti
-    respond_to :xml
 
     def index
       tool_config = ::IMS::LTI::ToolConfig.new(
@@ -14,7 +13,7 @@ module DceLti
         engine_config.tool_config_extensions.call(self, tool_config)
       end
 
-      respond_with tool_config
+      render xml: tool_config
     end
 
     private

--- a/lib/dce_lti/version.rb
+++ b/lib/dce_lti/version.rb
@@ -1,3 +1,3 @@
 module DceLti
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end


### PR DESCRIPTION
This allows us to avoid including the "responders" gem in rails 4.2.1 
projects.