### PR TITLE
Redirect after session expire

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,11 @@ through the controller instance passed to it.
 
 ### Invalid LTI Sessions
 
-If an LTI session cannot be validated, `dce_lti/sessions/invalid` will be
+If an LTI session cannot be validated, by default `dce_lti/sessions/invalid` will be
 rendered. You can customize this output by creating a file named
 `app/views/dce_lti/sessions/invalid.html.erb`, per the default engine view
-resolution behavior.
+resolution behavior. It is also possible to configure your own redirect url via 
+'redirect_after_session_expire' setting in dce_lti_config.
 
 ### Cookieless Sessions - Experimental
 

--- a/lib/dce_lti/controller_methods.rb
+++ b/lib/dce_lti/controller_methods.rb
@@ -1,8 +1,8 @@
 module DceLti
   module ControllerMethods
     def authenticate_via_lti
-      if ! current_user
-        redirect_to Engine.routes.url_helpers.invalid_sessions_path
+      unless current_user
+        redirect_to redirect_after_session_expire
       end
     end
 
@@ -18,6 +18,10 @@ module DceLti
     def cookieless_session?
       cookie = env.fetch('HTTP_COOKIE', '')
       cookie.blank? || cookie.match(/shimmed_cookie/)
+    end
+    
+    def redirect_after_session_expire
+      Engine.config.redirect_after_session_expire.call(self)
     end
   end
 end

--- a/lib/dce_lti/engine.rb
+++ b/lib/dce_lti/engine.rb
@@ -24,6 +24,10 @@ launch_presentation_return_url
         session_key_name = Rails.application.config.session_options[:key]
         Rails.application.routes.url_helpers.root_path(session_key_name => controller.session.id)
       end
+      
+      config.redirect_after_session_expire = -> (controller) do
+        Engine.routes.url_helpers.invalid_sessions_path
+      end
 
       config.tool_config_extensions = ->(*) {}
       yield config

--- a/spec/controllers/dce_lti/configs_controller_spec.rb
+++ b/spec/controllers/dce_lti/configs_controller_spec.rb
@@ -2,11 +2,13 @@ module DceLti
   describe ConfigsController do
     include ConfigurationHelpers
 
+    routes { DceLti::Engine.routes }
+
     context '#index' do
       it 'uses IMS::LTI::ToolConfig to construct the tool config' do
         configurer_double = create_configurer_double
 
-        get :index, { format: :xml, use_route: :dce_lti }
+        get :index, { format: :xml }
 
         expect(configurer_double).to have_received(:to_xml)
       end
@@ -14,7 +16,7 @@ module DceLti
       it 'renders XML' do
         create_configurer_double
 
-        get :index, {format: :xml, use_route: :dce_lti }
+        get :index, {format: :xml }
 
         expect(response.content_type).to eq 'application/xml'
       end
@@ -24,7 +26,7 @@ module DceLti
         allow(controller).to receive(:sessions_url).and_return(sessions_url)
         create_configurer_double
 
-        get :index, {format: :xml, use_route: :dce_lti }
+        get :index, {format: :xml }
 
         expect(IMS::LTI::ToolConfig).to have_received(:new).with(
           hash_including(launch_url: sessions_url)
@@ -40,7 +42,7 @@ module DceLti
           tool_config.canvas_domain!(controller.awesome_method)
         }
         with_overridden_lti_config_of({tool_config_extensions: tool_config_extensions}) do
-          get :index, { format: :xml, use_route: :dce_lti }
+          get :index, { format: :xml}
           expect(controller).to have_received(:awesome_method)
         end
       end
@@ -48,7 +50,7 @@ module DceLti
       it 'passes in the correct variables' do
         with_overridden_lti_config_of({}) do |lti_config|
           create_configurer_double
-          get :index, { format: :xml, use_route: :dce_lti }
+          get :index, { format: :xml}
 
           expect(IMS::LTI::ToolConfig).to have_received(:new).with(
             hash_including(

--- a/spec/controllers/dce_lti/sessions_controller_spec.rb
+++ b/spec/controllers/dce_lti/sessions_controller_spec.rb
@@ -2,6 +2,8 @@ module DceLti
   describe SessionsController do
     include ConfigurationHelpers
 
+    routes { DceLti::Engine.routes }
+
     context '#create' do
       it 'validates the timestamp' do
         timestamp="a timestamp"
@@ -203,7 +205,7 @@ module DceLti
     end
 
     def post_to_create_with_params(params_to_merge = {})
-      post :create, { use_route: :dce_lti }.merge(params_to_merge)
+      post :create, params_to_merge
     end
 
     def captured_attributes

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/spec/dummy/config/initializers/dce_lti_config.rb
+++ b/spec/dummy/config/initializers/dce_lti_config.rb
@@ -20,6 +20,12 @@ DceLti::Engine.setup do |lti|
   #   session_key_name = Rails.application.config.session_options[:key]
   #   Rails.application.routes.url_helpers.root_path(session_key_name => controller.session.id)
   # }
+  #
+  # The default redirect when session is expired, redirects to sessions_invalid_path.
+  #
+  # lti.redirect_after_session_expire = ->(controller) {
+  #   Rails.application.routes.url_helpers.signin_path
+  # }
 
   lti.consumer_secret = (ENV['LTI_CONSUMER_SECRET'] || 'consumer_secret')
   lti.consumer_key = (ENV['LTI_CONSUMER_KEY'] || 'consumer_key')


### PR DESCRIPTION
I made this PR to customise the redirect after session expire.
The default stays the same to invalid_session_path, but it is now possible to set your own route in the config.
